### PR TITLE
Add line break opportunities to endpoint titles

### DIFF
--- a/src/_plugins/endpoint.rb
+++ b/src/_plugins/endpoint.rb
@@ -1,0 +1,17 @@
+module Jekyll
+  class EndpointTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      params = text.split(" ")
+      @method = params[0]
+      @url = params[1]
+    end
+
+    def render(context)
+      "#{@method} <code>#{@url.gsub('/', "/<wbr>")}</code>"
+    end
+  end
+end
+
+Liquid::Template.register_tag('endpoint', Jekyll::EndpointTag)

--- a/src/accounts.md
+++ b/src/accounts.md
@@ -20,7 +20,7 @@ resources owned by the account.
 
 ## Creating an account
 
-POST `https://service.centrapay.com/api/accounts`
+{% endpoint POST https://service.centrapay.com/api/accounts %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/accounts" \
@@ -61,7 +61,7 @@ curl -X POST "https://service.centrapay.com/api/accounts" \
 
 ## Get information about an account
 
-GET `https://service.centrapay.com/api/accounts/{accountId}`
+{% endpoint GET https://service.centrapay.com/api/accounts/{accountId} %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk" \
@@ -112,7 +112,7 @@ curl -X GET "https://service.centrapay.com/api/account-memberships" \
 ## Update an account
 
 
-PUT `https://service.centrapay.com/api/accounts/{accountId}`
+{% endpoint PUT https://service.centrapay.com/api/accounts/{accountId} %}
 
 ```sh
 curl -X PUT "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk" \
@@ -144,7 +144,7 @@ curl -X PUT "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk" 
 
 ## Creating an API key
 
-POST `https://service.centrapay.com/api/accounts/{accountId}/api-keys`
+{% endpoint POST https://service.centrapay.com/api/accounts/{accountId}/api-keys %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys" \
@@ -175,7 +175,7 @@ curl -X POST "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/
 
 ## List account API keys
 
-GET `https://service.centrapay.com/api/accounts/{accountId}/api-keys`
+{% endpoint GET https://service.centrapay.com/api/accounts/{accountId}/api-keys %}
 
 ```sh
 curl "http://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys"
@@ -204,7 +204,7 @@ curl "http://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys"
 
 ## Update account API key
 
-PUT `https://service.centrapay.com/api/accounts/{accountId}/api-keys/{apikey-name}`
+{% endpoint PUT https://service.centrapay.com/api/accounts/{accountId}/api-keys/{apikey-name} %}
 
 ```sh
 curl -X PUT "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys/MyAPIkey" \
@@ -233,7 +233,7 @@ curl -X PUT "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/a
 
 ## Add account member **EXPERIMENTAL**
 
-POST `https://service.centrapay.com/api/accounts/${accountId}/members`
+{% endpoint POST https://service.centrapay.com/api/accounts/${accountId}/members %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/members" \
@@ -267,7 +267,7 @@ curl -X POST "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/
 
 ## List account members
 
-GET `https://service.centrapay.com/api/accounts/{accountId}/members`
+{% endpoint GET https://service.centrapay.com/api/accounts/{accountId}/members %}
 
 ```sh
 curl -X GET http://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/members \

--- a/src/fiat/authorities.md
+++ b/src/fiat/authorities.md
@@ -21,7 +21,7 @@ Centrapay account that the wallet belongs to.
 
 ## Creating a bank authority
 
-**POST** `https://service.centrapay.com/api/bank-authorities`
+{% endpoint POST https://service.centrapay.com/api/bank-authorities %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/bank-authorities" \
@@ -86,7 +86,7 @@ curl -X POST "https://service.centrapay.com/api/bank-authorities" \
 
 ## Get information about a bank authority
 
-**GET** `https://service.centrapay.com/api/bank-authorities/{id}`
+{% endpoint GET https://service.centrapay.com/api/bank-authorities/{id} %}
 
 ```sh
 curl -X GET `https://service.centrapay.com/api/bank-authorities/Jaim1Cu1Q55uooxSens6yk` \
@@ -95,7 +95,7 @@ curl -X GET `https://service.centrapay.com/api/bank-authorities/Jaim1Cu1Q55uooxS
 
 **Example response payload**
 
-```JSON
+```json
 {
     "id": "WRhAxxWpTKb5U7pXyxQjjY",
     "accountId": "Jaim1Cu1Q55uooxSens6yk",
@@ -119,7 +119,7 @@ curl -X GET `https://service.centrapay.com/api/bank-authorities/Jaim1Cu1Q55uooxS
 
 ## List authorized bank authorities
 
-**GET** `https://service.centrapay.com/api/bank-authorities`
+{% endpoint GET https://service.centrapay.com/api/bank-authorities %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/bank-authorities" \
@@ -153,7 +153,7 @@ curl -X GET "https://service.centrapay.com/api/bank-authorities" \
 
 ## Verify a bank authority
 
-**POST** `https://service.centrapay.com/api/bank-authorities/{id}/verify`
+{% endpoint POST https://service.centrapay.com/api/bank-authorities/{id}/verify %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/bank-authorities/WRhAxxWpTKb5U7pXyxQjjY/verify" \

--- a/src/fiat/funds-transfers.md
+++ b/src/fiat/funds-transfers.md
@@ -18,7 +18,7 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
 ## Creating a top up
 
-**POST** `https://service.centrapay.com/api/topups`
+{% endpoint POST https://service.centrapay.com/api/topups %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/topups" \
@@ -57,7 +57,7 @@ curl -X POST "https://service.centrapay.com/api/topups" \
 
 ## Getting a top up by id
 
-**GET** `https://service.centrapay.com/api/topups/${id}`
+{% endpoint GET https://service.centrapay.com/api/topups/${id} %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/topups/WRhAxxWpTKb5U7pXyxQjjY" \
@@ -82,7 +82,7 @@ curl -X GET "https://service.centrapay.com/api/topups/WRhAxxWpTKb5U7pXyxQjjY" \
 
 ## List top ups for a bank authority
 
-**GET** `https://service.centrapay.com/topups`
+{% endpoint GET https://service.centrapay.com/topups %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/topups" \

--- a/src/fiat/wallets.md
+++ b/src/fiat/wallets.md
@@ -19,7 +19,7 @@ account has access to.
 
 ## Creating a wallet
 
-POST `https://service.centrapay.com/api/wallets`
+{% endpoint POST https://service.centrapay.com/api/wallets %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/wallets" \
@@ -49,7 +49,7 @@ curl -X POST "https://service.centrapay.com/api/wallets" \
 
 ## Listing authorized wallets
 
-GET `https://service.centrapay.com/api/wallets`
+{% endpoint GET https://service.centrapay.com/api/wallets %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/wallets" \
@@ -79,7 +79,7 @@ curl -X GET "https://service.centrapay.com/api/wallets" \
 
 ## Listing Wallet Transactions **EXPERIMENTAL**
 
-GET `https://service.centrapay.com/api/wallets/${walletId}/transactions`
+{% endpoint GET https://service.centrapay.com/api/wallets/${walletId}/transactions %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/wallets/WRhAxxWpTKb5U7pXyxQjjY/transactions" \

--- a/src/merchants.md
+++ b/src/merchants.md
@@ -18,7 +18,7 @@ configurations with different payment methods.
 
 ## Creating merchant
 
-POST `https://service.centrapay.com/api/merchants`
+{% endpoint POST https://service.centrapay.com/api/merchants %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/merchants" \
@@ -61,7 +61,7 @@ curl -X POST "https://service.centrapay.com/api/merchants" \
 
 ## Get information about a merchant
 
-GET `https://service.centrapay.com/api/merchants/{merchantId}`
+{% endpoint GET https://service.centrapay.com/api/merchants/{merchantId} %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07f" \
@@ -82,7 +82,7 @@ curl -X GET "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07
 
 ## Update a merchant
 
-PUT `https://service.centrapay.com/api/merchants/{merchantId}`
+{% endpoint PUT https://service.centrapay.com/api/merchants/{merchantId} %}
 
 ```sh
 curl -X PUT "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07f" \
@@ -113,7 +113,7 @@ curl -X PUT "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07
 
 ## Creating merchant configuration
 
-POST `https://service.centrapay.com/api/merchants/{merchantId}/configs/`
+{% endpoint POST https://service.centrapay.com/api/merchants/{merchantId}/configs/ %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07f/configs/" \
@@ -147,7 +147,7 @@ curl -X POST "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a0
 
 ## Get merchant configuration
 
-GET `https://service.centrapay.com/api/merchants/{merchantId}/configs/{id}`
+{% endpoint GET https://service.centrapay.com/api/merchants/{merchantId}/configs/{id} %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07f/configs/5ee168e8597be5002af7b454" \
@@ -170,7 +170,7 @@ curl -X GET "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07
 
 ## List all merchant configurations
 
-GET `https://service.centrapay.com/api/merchants/{merchantId}/configs/`
+{% endpoint GET https://service.centrapay.com/api/merchants/{merchantId}/configs/ %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07f/configs/" \
@@ -204,7 +204,7 @@ curl -X GET "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07
 
 ## Update merchant configuration
 
-PUT `https://service.centrapay.com/api/merchants/{merchantId}/configs/{id}`
+{% endpoint PUT https://service.centrapay.com/api/merchants/{merchantId}/configs/{id} %}
 
 ```sh
 curl -X PUT "https://service.centrapay.com/api/merchants/5ee0c486308f590260d9a07f/configs/5ee168e8597be5002af7baed/" \

--- a/src/transacting.md
+++ b/src/transacting.md
@@ -39,7 +39,7 @@ Our payments endpoints have interactive Swagger documentation at
 
 [Swagger Docs](https://service.centrapay.com/payments/api/documentation#/Requests/postRequestscreate){:target="\_blank"}{:.external}
 
-**POST** https://service.centrapay.com/payments/api/requests.create
+{% endpoint POST https://service.centrapay.com/payments/api/requests.create %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/payments/api/requests.create" \
@@ -74,7 +74,7 @@ curl -X POST "https://service.centrapay.com/payments/api/requests.create" \
 
 [Swagger Docs](https://service.centrapay.com/payments/api/documentation#/Requests/getRequestsinfo){:target="\_blank"}{:.external}
 
-**GET** https://service.centrapay.com/payments/api/requests.info
+{% endpoint GET https://service.centrapay.com/payments/api/requests.info %}
 
 ```sh
 curl -G "https://service.centrapay.com/payments/api/requests.info" \
@@ -93,7 +93,7 @@ curl -G "https://service.centrapay.com/payments/api/requests.info" \
 
 [Swagger Docs](https://service.centrapay.com/payments/api/documentation#/Requests/postRequestspay){:target="\_blank"}{:.external}
 
-**POST** https://service.centrapay.com/payments/api/requests.pay
+{% endpoint POST https://service.centrapay.com/payments/api/requests.pay %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/payments/api/requests.pay" \
@@ -138,7 +138,7 @@ text rates from your provider.
 
 [Swagger Docs](https://service.centrapay.com/payments/api/documentation#/Requests/postRequestscancel){:target="\_blank"}{:.external}
 
-**POST** https://service.centrapay.com/payments/api/requests.cancel
+{% endpoint POST https://service.centrapay.com/payments/api/requests.cancel %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/payments/api/requests.cancel" \
@@ -157,7 +157,7 @@ curl -X POST "https://service.centrapay.com/payments/api/requests.cancel" \
 
 [Swagger Docs](https://service.centrapay.com/payments/api/documentation#/Requests/postRequestsvoid){:target="\_blank"}{:.external}
 
-**POST** https://service.centrapay.com/payments/api/requests.void
+{% endpoint POST https://service.centrapay.com/payments/api/requests.void %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/payments/api/requests.void" \
@@ -176,7 +176,7 @@ curl -X POST "https://service.centrapay.com/payments/api/requests.void" \
 
 [Swagger Docs](https://service.centrapay.com/payments/api/documentation#/Transactions/postTransactionsrefund){:target="\_blank"}{:.external}
 
-**POST** https://service.centrapay.com/payments/api/transactions.refund
+{% endpoint POST https://service.centrapay.com/payments/api/transactions.refund %}
 
 ```sh
 curl -X POST "https://service.centrapay.com/payments/api/transactions.refund" \


### PR DESCRIPTION
Firefox breaks words on hyphens and slashes but Chrome only breaks on
hyphens.