### PR TITLE
Change ruby setup method to use supported project

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          bundler-cache: true
       - uses: actions/cache@v1
         with:
           path: vendor/bundle


### PR DESCRIPTION
Looks like they've archived actions/setup-ruby and the recommendation is
to move to ruby/setup-ruby so that's what this change does.

We have a .ruby-version so it looks like the explicit version isn't
needed. The bundler-cache option just seems like a sensible option.