### PR TITLE
Document Withdrawls and adjust Bank Authority requirements

### DIFF
--- a/src/accounts.md
+++ b/src/accounts.md
@@ -131,9 +131,9 @@ curl -X POST "https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/
 
 **Required Fields**
 
-| Field |  Type  |                                    Description                                     |
-| :---- | :----- | :--------------------------------------------------------------------------------- |
-| name  | String | The alphanumeric name of the API key, must be unique within account                |
+| Field |  Type  |                                    Description                                      |
+| :---- | :----- | :---------------------------------------------------------------------------------- |
+| name  | String | The alphanumeric name of the API key, must be unique within account                 |
 | role  | String | API key role. Currently, only supported are "merchant-terminal" and "account-owner" |
 
 **Example response payload**

--- a/src/fiat/funds-transfers.md
+++ b/src/fiat/funds-transfers.md
@@ -34,7 +34,7 @@ curl -X POST "https://service.centrapay.com/api/topups" \
 **Required Fields**
 
 |      Field      |  Type  |               Description                |
-|:--------------- |:------ |:---------------------------------------- |
+| :-------------- | :----- | :--------------------------------------- |
 | amount          | String | Total amount of the transaction in cents |
 | walletId        | String | The id of the wallet                     |
 | bankAuthorityId | String | The id of the bank authority             |
@@ -57,14 +57,15 @@ curl -X POST "https://service.centrapay.com/api/topups" \
 
 **Error Responses**
 
-| Status |             Code              |                         Description                         |
-| :----- | :---------------------------- | :---------------------------------------------------------- |
-| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %} | The wallet and the bank authority for the top up request do not belong to the same account. |
-| 403    | {% break _ MAX_INFLIGHT_TOPUPS_EXCEEDED %}   | The bank authority already has ten pending top ups, which is the maximum a bank authority can have at any one time. |
+| Status |                       Code                       |                                                                                                             Description                                                                                                              |
+| :----- | :----------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %}     | The wallet and the bank authority for the top up request do not belong to the same account.                                                                                                                                          |
+| 403    | {% break _ MAX_INFLIGHT_TOPUPS_EXCEEDED %}       | The bank authority already has ten pending top ups, which is the maximum a bank authority can have at any one time.                                                                                                                  |
 | 403    | {% break _ MAX_INFLIGHT_TOPUP_AMOUNT_EXCEEDED %} | The top up can not be created because it is above the max amount of funds a bank authority can have pending at any one time. The max amount is $1000.00 for verified bank authorities and $100.00 for non-verified bank authorities. |
-| 403    | {% break _ QUOTA_EXCEEDED %} | The topup exceeds one or more topup quota limits see [ Quota Error Response ]({% link quotas.md %}#quota-error-response)  |
+| 403    | {% break _ QUOTA_EXCEEDED %}                     | The topup exceeds one or more topup quota limits see [ Quota Error Response ]({% link quotas.md %}#quota-error-response)                                                                                                             |
+| 403    | {% break _ DIRECT_DEBIT_NOT_AUTHORIZED        %} | Bank authority requires authorization for topup. See bank authorities [direct debit endpoint]({% link fiat/bank-authorities.md %}#direct-debit-authority).                                                                           |
 
-## Getting a top up by id
+## Get a top up by id
 
 {% endpoint GET https://service.centrapay.com/api/topups/${id} %}
 
@@ -91,7 +92,7 @@ curl -X GET "https://service.centrapay.com/api/topups/WRhAxxWpTKb5U7pXyxQjjY" \
 
 ## List top ups for authorized accounts
 
-{% endpoint GET https://service.centrapay.com/topups %}
+{% endpoint GET https://service.centrapay.com/api/topups %}
 
 ```sh
 curl -X GET "https://service.centrapay.com/api/topups" \
@@ -163,4 +164,115 @@ curl -X GET "https://service.centrapay.com/api/accounts/aBc932S9182qwCDqwer/topu
     "updatedAt": "2020-05-01T12:30:00.000Z"
   }
 ]
+```
+
+## Creating a Withdrawal **EXPERIMENTAL**
+
+{% endpoint POST https://service.centrapay.com/api/withdrawals %}
+
+```sh
+curl -X POST "https://service.centrapay.com/api/withdrawals" \
+  -H "x-api-key: 1234" \
+  -H "content-type: application/json" \
+  -d '{
+    "amount": "10000",
+    "walletId": "Te2uDM7xhDLWGVJU3nzwnh",
+    "bankAuthorityId": "FRhAzzWpTKb5U7pZygQjjY"
+  }'
+```
+
+**Required Fields**
+
+|      Field      |  Type  |               Description                |
+| :-------------- | :----- | :--------------------------------------- |
+| amount          | String | Total amount of the transaction in cents |
+| walletId        | String | The id of the wallet                     |
+| bankAuthorityId | String | The id of the bank authority             |
+
+**Example response payload**
+
+```json
+{
+  "id": "hg2RfYTQ635tPBZEPJdCre",
+  "walletId": "Te2uDM7xhDLWGVJU3nzwnh",
+  "bankAuthorityId": "FRhAzzWpTKb5U7pZygQjjY",
+  "accountId": "aBc932S9182qwCDqwer",
+  "type": "withdrawal",
+  "amount": "10000",
+  "status": "created",
+  "createdAt": "2020-05-01T12:30:00.000Z",
+  "updatedAt": "2020-05-01T12:30:00.000Z"
+}
+```
+
+**Error Responses**
+
+| Status |                     Code                      |                                         Description                                             |
+| :----- | :-------------------------------------------- | :---------------------------------------------------------------------------------------------- |
+| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %}  | The wallet and the bank authority for the withdrawal request do not belong to the same account. |
+| 403    | {% break _ INSUFFICIENT_WALLET_BALANCE %}     | The wallet balance is less than the required amount.                                            |
+
+## Get a Withdrawal by id **EXPERIMENTAL**
+
+{% endpoint GET https://service.centrapay.com/api/withdrawals/${id} %}
+
+```sh
+curl -X GET "https://service.centrapay.com/api/withdrawals/WRhAxxWpTKb5U7pXyxQjjY" \
+  -H "x-api-key: 1234"
+```
+
+**Example response payload**
+
+```json
+{
+  "id": "hg2RfYTQ635tPBZEPJdCre",
+  "walletId": "Te2uDM7xhDLWGVJU3nzwnh",
+  "bankAuthorityId": "FRhAzzWpTKb5U7pZygQjjY",
+  "accountId": "aBc932S9182qwCDqwer",
+  "type": "withdrawal",
+  "amount": "10000",
+  "status": "created",
+  "createdAt": "2020-05-01T12:30:00.000Z",
+  "updatedAt": "2020-05-01T12:30:00.000Z"
+}
+```
+
+## List withdrawals for an account **EXPERIMENTAL**
+
+{% endpoint GET https://service.centrapay.com/api/accounts/${accountId}/withdrawals %}
+
+```sh
+curl -X GET "https://service.centrapay.com/api/accounts/aBc932S9182qwCDqwer/withdrawals" \
+  -H "x-api-key: 1234"
+```
+
+**Example response payload**
+
+```json
+{
+  "items": [
+    {
+      "id": "5thg2RPBZEfYTPJdQ63Cre",
+      "walletId": "Te2uDM7xhDLWGVJU3nzwnh",
+      "bankAuthorityId": "FRhAzzWpTKb5U7pZygQjjY",
+      "accountId": "aBc932S9182qwCDqwer",
+      "type": "withdrawal",
+      "amount": "10000",
+      "status": "created",
+      "createdAt": "2020-05-01T12:30:00.000Z",
+      "updatedAt": "2020-05-01T12:30:00.000Z"
+    },
+    {
+      "id": "hg2RfYTQ635tPBZEPJdCre",
+      "walletId": "Te2uDM7xhDLWGVJU3nzwnh",
+      "bankAuthorityId": "FRhAzzWpTKb5U7pZygQjjY",
+      "accountId": "aBc932S9182qwCDqwer",
+      "type": "withdrawal",
+      "amount": "10000",
+      "status": "done",
+      "createdAt": "2020-05-01T12:30:00.000Z",
+      "updatedAt": "2020-05-01T12:30:00.000Z"
+    }
+  ]
+}
 ```


### PR DESCRIPTION
We need to make several fields optional in order to be able to support minimal information for withdrawls.

We also need to be able to track this information as it's till required for top ups.

Updates cover bank accounts and also withdraws pages.