### PR TITLE
Rework references to bank account

### DIFF
--- a/src/auth.md
+++ b/src/auth.md
@@ -132,8 +132,8 @@ indicated below with a star (✸).
 | {% break : asset-transfers:create  %} | &nbsp;&nbsp; ✅ |               |                   |
 | {% break : asset-transfers:read    %} | &nbsp;&nbsp; ✅ |               |                   |
 | {% break : asset-transfers:claim   %} | &nbsp;&nbsp; ✅ |               |                   |
-| {% break : bank-authorities:create %} | &nbsp;&nbsp; ✅ |               |                   |
-| {% break : bank-authorities:read   %} | &nbsp;&nbsp; ✅ |               |                   |
+| {% break : bank-accounts:create %}    | &nbsp;&nbsp; ✅ |               |                   |
+| {% break : bank-accounts:read   %}    | &nbsp;&nbsp; ✅ |               |                   |
 | {% break : quotas:read             %} | &nbsp;&nbsp; ✅ |               |                   |
 
 

--- a/src/fiat/bank-accounts.md
+++ b/src/fiat/bank-accounts.md
@@ -1,14 +1,15 @@
 ---
 layout:  default
 parent:  Fiat
-title: Bank Authorities
+title: Bank Accounts
 ---
 
-# Bank Authorities
+# Bank Accounts
 {:.no_toc}
 
-A bank authority represents an individual's consent for Centrapay to transfer funds to and from a
-bank account.
+A Bank Account is a way to get funds in and out of a user's wallet.
+
+A Bank Authority represents an individual's consent for Centrapay to transfer funds.
 
 In order to move funds from a Centrapay wallet to a bank account (withdrawal), we only need the
 minimum required fields. There's no need to authorize direct debit authority, nor verify the account
@@ -29,7 +30,7 @@ be observed based on the `directDebitAuthorized` and `verified` flags.
 
 {% endpoint POST https://service.centrapay.com/api/bank-accounts %}
 
-An example of a minimal POST to create a bank authority.
+An example of a minimal POST to create a bank account.
 
 ```sh
 curl -X POST "https://service.centrapay.com/api/bank-accounts" \
@@ -42,7 +43,7 @@ curl -X POST "https://service.centrapay.com/api/bank-accounts" \
   }'
 ```
 
-An example of a minimal POST to create a bank authority and a direct debit authority.
+An example of a minimal POST to create a bank account and a direct debit authority.
 
 By including directDebitAuthority, the user accepts our [Direct Debit terms][dd-terms]{:.external}
 and has authority to operate this account.
@@ -396,10 +397,10 @@ curl -X POST "https://service.centrapay.com/api/bank-authorities" \
 
 **Error Responses**
 
-| Status |             Code                                         |                         Description                                                                        |
-| :----- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
-| 403    | {% break _ BANK_AUTHORITY_LIMIT_EXCEEDED %}              | The account already has the max amount of bank authorities.                                                |
-| 403    | {% break _ BANK_AUTHORITIES_FOR_BANK_ACCOUNT_EXCEEDED %} | There are already two bank authorities for the provided bank account number, which is the maximum allowed. |
+| Status |             Code                                         |                         Description                                                                     |
+| :----- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| 403    | {% break _ BANK_AUTHORITY_LIMIT_EXCEEDED %}              | The account already has the max amount of bank accounts.                                                |
+| 403    | {% break _ BANK_AUTHORITIES_FOR_BANK_ACCOUNT_EXCEEDED %} | There are already two bank accounts for the provided bank account number, which is the maximum allowed. |
 
 ## Get information about a bank authority **DEPRECATED**
 

--- a/src/fiat/funds-transfers.md
+++ b/src/fiat/funds-transfers.md
@@ -37,7 +37,7 @@ curl -X POST "https://service.centrapay.com/api/topups" \
 | :-------------- | :----- | :--------------------------------------- |
 | amount          | String | Total amount of the transaction in cents |
 | walletId        | String | The id of the wallet                     |
-| bankAuthorityId | String | The id of the bank authority             |
+| bankAuthorityId | String | The id of the bank account               |
 
 **Example response payload**
 
@@ -57,13 +57,13 @@ curl -X POST "https://service.centrapay.com/api/topups" \
 
 **Error Responses**
 
-| Status |                       Code                       |                                                                                                             Description                                                                                                              |
-| :----- | :----------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %}     | The wallet and the bank authority for the top up request do not belong to the same account.                                                                                                                                          |
-| 403    | {% break _ MAX_INFLIGHT_TOPUPS_EXCEEDED %}       | The bank authority already has ten pending top ups, which is the maximum a bank authority can have at any one time.                                                                                                                  |
-| 403    | {% break _ MAX_INFLIGHT_TOPUP_AMOUNT_EXCEEDED %} | The top up can not be created because it is above the max amount of funds a bank authority can have pending at any one time. The max amount is $1000.00 for verified bank authorities and $100.00 for non-verified bank authorities. |
-| 403    | {% break _ QUOTA_EXCEEDED %}                     | The topup exceeds one or more topup quota limits see [ Quota Error Response ]({% link quotas.md %}#quota-error-response)                                                                                                             |
-| 403    | {% break _ DIRECT_DEBIT_NOT_AUTHORIZED        %} | Bank authority requires authorization for topup. See bank authorities [direct debit endpoint]({% link fiat/bank-authorities.md %}#direct-debit-authority).                                                                           |
+| Status |                       Code                       |                                                                                                             Description                                                                                                      |
+| :----- | :----------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %}     | The wallet and the bank account for the top up request do not belong to the same account.                                                                                                                                    |
+| 403    | {% break _ MAX_INFLIGHT_TOPUPS_EXCEEDED %}       | The bank account already has ten pending top ups, which is the maximum a bank authority can have at any one time.                                                                                                            |
+| 403    | {% break _ MAX_INFLIGHT_TOPUP_AMOUNT_EXCEEDED %} | The top up can not be created because it is above the max amount of funds a bank account can have pending at any one time. The max amount is $1000.00 for verified bank accounts and $100.00 for non-verified bank accounts. |
+| 403    | {% break _ QUOTA_EXCEEDED %}                     | The topup exceeds one or more topup quota limits see [ Quota Error Response ]({% link quotas.md %}#quota-error-response)                                                                                                     |
+| 403    | {% break _ DIRECT_DEBIT_NOT_AUTHORIZED        %} | Bank account requires authorization for topup. See bank accounts [direct debit endpoint]({% link fiat/bank-accounts.md %}#direct-debit-authority).                                                                           |
 
 ## Get a top up by id
 
@@ -187,7 +187,7 @@ curl -X POST "https://service.centrapay.com/api/withdrawals" \
 | :-------------- | :----- | :--------------------------------------- |
 | amount          | String | Total amount of the transaction in cents |
 | walletId        | String | The id of the wallet                     |
-| bankAuthorityId | String | The id of the bank authority             |
+| bankAuthorityId | String | The id of the bank account               |
 
 **Example response payload**
 
@@ -207,10 +207,10 @@ curl -X POST "https://service.centrapay.com/api/withdrawals" \
 
 **Error Responses**
 
-| Status |                     Code                      |                                         Description                                             |
-| :----- | :-------------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %}  | The wallet and the bank authority for the withdrawal request do not belong to the same account. |
-| 403    | {% break _ INSUFFICIENT_WALLET_BALANCE %}     | The wallet balance is less than the required amount.                                            |
+| Status |                     Code                      |                                         Description                                           |
+| :----- | :-------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| 403    | {% break _ BANK_AUTHORITY_WALLET_MISMATCH %}  | The wallet and the bank account for the withdrawal request do not belong to the same account. |
+| 403    | {% break _ INSUFFICIENT_WALLET_BALANCE %}     | The wallet balance is less than the required amount.                                          |
 
 ## Get a Withdrawal by id **EXPERIMENTAL**
 

--- a/src/fiat/index.md
+++ b/src/fiat/index.md
@@ -7,8 +7,7 @@ has_children: true
 # Fiat
 {:.no_toc}
 
-Fiat currency transactions operate on Wallets. Wallets are topped up by
-making Funds Transfers via Bank Authorities.
+Fiat currency transactions operate on Wallets.
 
 * TOC
 {:toc}


### PR DESCRIPTION
We've separated bank accounts and bank authorities, so this just updates the terms in our documentation to match.