### PR TITLE
Remove link to developer application form

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -19,8 +19,5 @@ Checkout our [Guides][] for hints on where to begin or see the
 For more help getting setup, contact us via email at
 [devsupport@centrapay.com](mailto:devsupport@centrapay.com).
 
-
-[Developer Signup](https://centrapay.com/application-developer/){: .btn .btn-primary }
-
 [Guides]: {% link guides/introduction.md %}
 [API Reference]: {% link api/introduction.md %}


### PR DESCRIPTION
Nobody is checking this. If there's a process behind it we can put it back.