### PR TITLE
Create new payment requests page

### DIFF
--- a/src/_plugins/h4.rb
+++ b/src/_plugins/h4.rb
@@ -1,0 +1,15 @@
+module Jekyll
+  class H4Tag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      @text = text
+    end
+
+    def render(context)
+      %{<h4>#{@text}</h4>}
+    end
+  end
+end
+
+Liquid::Template.register_tag('h4', Jekyll::H4Tag)

--- a/src/_plugins/tab.rb
+++ b/src/_plugins/tab.rb
@@ -1,0 +1,14 @@
+module Jekyll
+  class TabTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+    end
+
+    def render(context)
+      "&nbsp;&nbsp;&nbsp;&nbsp;"
+    end
+  end
+end
+
+Liquid::Template.register_tag('tab', Jekyll::TabTag)

--- a/src/api/assets/assets.md
+++ b/src/api/assets/assets.md
@@ -30,12 +30,15 @@ rules governing how it can be obtained, shared or spent.
 * TOC
 {:toc}
 
-## Asset Model
+## Models
+
+### Asset
 
 All assets have the following fields along with the additional fields that are
 specific to its category.
 
-**Required Fields**
+
+{% h4 Required Fields %}
 
 | Field       | Type               | Description                                       |
 |:------------|:-------------------|:--------------------------------------------------|
@@ -49,7 +52,7 @@ specific to its category.
 | status      | String             | "active" if the asset can be used for payments.   |
 
 
-## Money
+### Money
 
 Money assets, being backed by real currency, are the most flexible asset types.
 Money is accepted for most payment requests, can be sent in arbitrary amounts
@@ -67,7 +70,7 @@ Money assets have the following fields along with the base asset fields.
 
 
 
-## Gift Cards
+### Gift Cards
 
 Gift cards are similar to money but have greater spending restrictions and are
 not always backed by real currency. Gift cards usually have an expiry date, are
@@ -95,7 +98,7 @@ Gift cards have the following fields along with the base asset fields.
 
 
 
-## Tokens (EXPERIMENTAL)
+### Tokens (EXPERIMENTAL)
 
 Tokens are assets which can be spent only once. They are usually tied to a
 small set of merchants and have an expiry date. Token value may be set in
@@ -105,9 +108,9 @@ Tokens have the following fields along with the base asset fields.
 
 **Required Fields**
 
-| Field | Type                  | Description                           |
-|:------|:----------------------|:--------------------------------------|
-| value | Array&lt;Token Value> | Token values in supported currencies. |
+| Field | Type  | Description                                                                                  |
+|:------|:------|:---------------------------------------------------------------------------------------------|
+| value | Array | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. |
 
 **Optional Fields**
 
@@ -116,15 +119,10 @@ Tokens have the following fields along with the base asset fields.
 | validFrom | {% dt Timestamp %} | The date when the asset becomes spendable. |
 | expiresAt | {% dt Timestamp %} | The date when the asset expires.           |
 
-**Token Value Object**
 
-| Field    | Type           | Description                                                |
-|:---------|:---------------|:-----------------------------------------------------------|
-| currency | String         | Currency code, eg "NZD".                                   |
-| amount   | {% dt BigNumber %} | Value in the currency's smallest denomination (ie. cents). |
+## Operations
 
-
-## Get Asset
+### Get Asset
 
 {% endpoint GET https://service.centrapay.com/api/assets/${id} %}
 
@@ -154,7 +152,7 @@ curl -X GET "https://service.centrapay.com/api/assets/L75M3L56N2PtBSt8g7uXLU" \
 }
 ```
 
-## List Assets for Account
+### List Assets for Account
 
 {% endpoint GET https://service.centrapay.com/api/accounts/${id}/assets %}
 
@@ -213,7 +211,7 @@ curl -X GET "https://service.centrapay.com/api/accounts/Te2uDM7xhDLWGVJU3nzwnh/a
 ```
 
 
-## Archive Asset (EXPERIMENTAL)
+### Archive Asset (EXPERIMENTAL)
 
 {% endpoint POST https://service.centrapay.com/api/assets/${id}/archive %}
 
@@ -251,6 +249,7 @@ curl -X POST "https://service.centrapay.com/api/assets/L75M3L56N2PtBSt8g7uXLU/ar
 | 403    | UNSUPPORTED_ASSET_TYPE  | Asset type can not be archived                      |
 
 
-[Payment Requests]: {% link api/transacting.md %}
+[Monetary Amounts]: {% link api/data-types.md %}#monetary
+[Payment Requests]: {% link api/payment-requests/payment-requests.md %}
 [Funds Transfers]: {% link api/bank-accounts/funds-transfers.md %}
 [Asset Transfers]: {% link api/assets/asset-transfers.md %}

--- a/src/api/bank-accounts/bank-accounts.md
+++ b/src/api/bank-accounts/bank-accounts.md
@@ -3,6 +3,7 @@ layout:  default
 grand_parent: API Reference
 parent: Bank Accounts
 title: Bank Accounts
+nav_order: 1
 permalink: /api/bank-accounts
 redirect_from:
   - /fiat

--- a/src/api/data-types.md
+++ b/src/api/data-types.md
@@ -12,8 +12,8 @@ permalink: /api/data-types
 ## Timestamp
 
 A point in time, usually with millisecond precision, represented as an
-[ISO8601][] date string (eg "2021-06-11T02:51:11.000Z"). Timestamps are in the
-UTC timezone as denoted by the "Z" suffix.
+[ISO8601][]{:.external} date string (eg "2021-06-11T02:51:11.000Z"). Timestamps
+are in the UTC timezone as denoted by the "Z" suffix.
 
 
 ## BigNumber
@@ -24,4 +24,20 @@ etc) represent the value as BigNumbers. Depending on the context, a BigNumber
 may be used to represent an integer or a decimal amount.
 
 
+## Monetary
+
+A monetary amount in a currency, represented as an Object. The amount is
+usually an integer in the smallest denomination for the currency (ie cents) but
+may be a decimal value for some currencies (eg Bitcoin). The currency is
+typically represented as an [ISO4217][]{:.external} code.
+
+{% h4 Fields %}
+
+| Name     | Type               | Description                                                |
+|----------|--------------------|------------------------------------------------------------|
+| amount   | {% dt BigNumber %} | Value in the currency's smallest denomination (eg. cents). |
+| currency | String             | Currency code (eg. "NZD").                                 |
+
+
 [ISO8601]: https://en.wikipedia.org/wiki/ISO_8601
+[ISO4217]: https://en.wikipedia.org/wiki/ISO_4217

--- a/src/api/patron-codes.md
+++ b/src/api/patron-codes.md
@@ -117,4 +117,4 @@ curl -X GET https://service.centrapay.com/api/patron-codes/barcode/9990001234567
 }
 ```
 
-[polling]: {% link api/transacting.md %}#patron-code
+[polling]: {% link api/payment-requests/payment-requests.md %}#patron-code

--- a/src/api/payment-requests/index.md
+++ b/src/api/payment-requests/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+parent: API Reference
+title: Payment Requests
+has_children: true
+permalink: /api/section/payment-requests
+redirect_to: /api/payment-requests
+---

--- a/src/api/payment-requests/legacy-payment-requests.md
+++ b/src/api/payment-requests/legacy-payment-requests.md
@@ -1,28 +1,24 @@
 ---
 layout: default
-parent: API Reference
-title: Transacting
-nav_order: 3
-permalink: /api/transacting
+grand_parent: API Reference
+parent: Payment Requests
+title: Legacy
+permalink: /api/legacy-payment-requests
 redirect_from:
   - /transacting
+  - /api/transacting
 ---
 
-# Transacting
+# Legacy Payment Requests
 {:.no_toc}
 
+Centrapay Payment Requests are serviced via two sets of endpoints; the "next"
+version (documented [Payment Requests][]) and the "legacy" version
+(documented on this page). Use of legacy endpoints for new integrations is
+discouraged where alternative endpoints have been provided.
 
-Throughout our documentation we will talk about payment requests and
-transactions in several places, and it is important to know the difference. A
-payment request is generated when the [requests.create][] endpoint has been
-called. Payment Requests are then used to configure the different payment types
-a merchant accepts, set the amount of the transaction as well as the fiat
-currency e.g. NZD, and to set up any webhooks. Transactions are created when a
-payment request has been paid successfully via the [requests.pay][] endpoint, or
-when a completed transaction has been refunded via the [requests.void][] or
-[transactions.refund][] endpoint.
-
-Our payments endpoints also have [interactive Swagger documentation](https://service.centrapay.com/payments/api/documentation){:target="\_blank"}{:.external}.
+Legacy Payment Request endpoints also have
+[interactive Swagger documentation](https://service.centrapay.com/payments/api/documentation){:target="\_blank"}{:.external}.
 
 ## Contents
 {:.no_toc .text-delta}
@@ -88,51 +84,6 @@ curl -G "https://service.centrapay.com/payments/api/requests.info" \
 |:----------|:---------------------------------------------------------------------------|
 | requestId | The payment requestId that is generated when [requests.create][] is called |
 
-<a name="patron-code"></a>
-## Get a Payment Request using Patron Code id **EXPERIMENTAL**
-
-This is only available to the account which created the Patron Code for finding the Payment Request
-attached to it. If you didn't create the Patron Code or it doesn't exist, this will return a 403
-response.
-
-{% endpoint GET https://service.centrapay.com/api/patron-codes/{patronCodeId}/payment-request %}
-
-```sh
-curl -X GET "https://service.centrapay.com/api/patron-codes/DiBAKsHCeLNG9ai4LeLrhr/payment-request" \
-  -H "x-api-key: 1234"
-```
-
-**Example response payload when no Payment Request attached**
-
-```json
-{}
-```
-
-**Example response payload when a Payment Request is attached**
-
-```json
-{
-  "id": "207b5fb5-621e-4282-86c3-42ee47f87e74",
-  "patronCodeId": "V17FByEP9gm1shSG6a1Zzx",
-  "merchantId": "26d3Cp3rJmbMHnuNJmks2N",
-  "merchantName": "NZD Test Merchant",
-  "merchantConfigurationId": "5efbe2fb96c08357bb2b9242",
-  "value": { "currency": "NZD", "amount": "100" },
-  "paymentOptions": [
-    {
-      "amount": "100",
-      "assetType": "centrapay.nzd.test"
-    }
-  ],
-  "status": "new",
-  "createdAt": "2021-06-08T04:04:27.426Z",
-  "updatedAt": "2021-06-08T04:04:27.426Z",
-  "expiresAt": "2021-06-08T04:04:27.426Z",
-  "liveness": "test",
-  "expirySeconds": 120
-}
-```
-
 <a name="requests-pay">
 ## Paying a payment request
 
@@ -161,7 +112,7 @@ curl -X POST "https://service.centrapay.com/payments/api/requests.pay" \
 The "ledger" parameter indicates which payment option has been selected to pay
 the payment request. The selected payment option must be one of the options
 available for the payment request as per the `payments` array in the
-[requests.create][] and [requests.info][] responses. 
+[requests.create][] and [requests.info][] responses.
 
 The table below lists the possible ledger and authorization param values. The
 asset type is the value used to configure the merchant. The ledger param value
@@ -509,3 +460,4 @@ gmIjCXdv3VNvYfTsaBO5PJNiaD3l9lD8PzEQu31ePsOG81mDVuo40+dgLg==
 [requests.void]: #requests-void
 [requests.cancel]: #requests-cancel
 [transactions.refund]: #transactions-refund
+[Payment Requests]: {% link api/payment-requests/payment-requests.md %}

--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -1,0 +1,153 @@
+---
+layout:  default
+grand_parent: API Reference
+parent: Payment Requests
+title: Payment Requests
+nav_order: 1
+permalink: /api/payment-requests
+---
+
+# Payment Requests
+{:.no_toc}
+
+Payment Requests represent the intention for a merchant to receive payment for
+goods and services.  Payment Requests define the amount to be paid and the
+asset types that are acceptable for payment.
+
+A Payment Request is shared with, and paid by, a patron. The [Payment Flows Guide][]
+has more details regarding negotiation of Payment Requests.
+
+Payment Requests have the following statuses:
+
+ * **new**: after being created.
+ * **paid**: after being paid with one or more transactions.
+ * **cancelled**: after being cancelled or voided by the merchant.
+ * **expired**: after expiry time is reached without being paid or cancelled.
+
+Payment requests can also be refunded for a short period of time after being paid.
+
+Payment request state transitions can be notified to webhooks.
+
+Centrapay Payment Requests are serviced via two sets of endpoints; the "next"
+version (documented on this page) and the "legacy" version (documented at
+[Legacy Payment Requests][]).
+
+## Contents
+{:.no_toc .text-delta}
+
+* TOC
+{:toc}
+
+## Models
+
+### Payment Request
+
+{% h4 Mandatory Fields %}
+
+| Field          | Type               | Description                                                                 |
+|----------------|--------------------|-----------------------------------------------------------------------------|
+| id             | String             | The payment request id.                                                     |
+| value          | {% dt Monetary %}  | The canonical value of the payment request. Must be positive.               |
+| paymentOptions | Array              | The [Payment Options](#payment-option), indicating valid asset for payment. |
+| status         | String             | "new", "paid", "cancelled", "expired"                                       |
+| liveness       | String             | Indicates test assets are accepted. Values are "main" or "test".            |
+| createdAt      | {% dt Timestamp %} | When the payment request was created.                                       |
+| updatedAt      | {% dt Timestamp %} | When the payment request was updated.                                       |
+| expiresAt      | {% dt Timestamp %} | When the payment request expires.                                           |
+
+
+{% h4 Optional Fields %}
+
+| Field            | Type   | Description                                                          |
+|------------------|--------|----------------------------------------------------------------------|
+| patronCodeId     | String | The id of the [Patron Code][] the payment request is attached to.        |
+| merchantId       | String | The id of the merchant the payment request is on behalf of.          |
+| merchantName     | String | The name of the merchant the payment request is on behalf of.        |
+| merchantConfigId | String | The merchant configuration id used to configure the payment options. |
+| expirySeconds    | Number | The expiry seconds used to configure the payment request expiry.     |
+| lineItems        | Array  | **EXPERIMENTAL** The [Line Items](#line-item) being paid for.       |
+
+
+### Payment Option
+
+{% h4 Mandatory Fields %}
+
+| Field     | Type               | Description                                                             |
+|-----------|--------------------|-------------------------------------------------------------------------|
+| assetType | String             | An [Asset][] type reference.                                            |
+| amount    | {% dt BigNumber %} | The value required to pay using the canonical units for the asset type. |
+
+
+### Line Item
+
+An order item for which payment is requested. The currency and units for a line
+item price will be consistent with the payment request value and the sum of
+line item prices should equal the payment request value.
+
+A line item price can be negative to represents a discount.
+
+{% h4 Mandatory Fields %}
+
+| Field | Type               | Description                                                |
+|-------|--------------------|------------------------------------------------------------|
+| name  | String             | The product description.                                   |
+| sku   | String             | The product (stock keeping unit) code.                     |
+| qty   | {% dt BigNumber %} | The product quantity (eg. item count, weight, volume etc). |
+| price | {% dt BigNumber %} | The line price (eg. product price * qty).                  |
+
+
+## Operations
+
+<a name="patron-code"></a>
+### Get a Payment Request using Patron Code id **EXPERIMENTAL**
+
+This is only available to the account which created the Patron Code for finding the Payment Request
+attached to it. If you didn't create the Patron Code or it doesn't exist, this will return a 403
+response.
+
+{% endpoint GET https://service.centrapay.com/api/patron-codes/{patronCodeId}/payment-request %}
+
+```sh
+curl -X GET "https://service.centrapay.com/api/patron-codes/DiBAKsHCeLNG9ai4LeLrhr/payment-request" \
+  -H "x-api-key: 1234"
+```
+
+**Example response payload when no Payment Request attached**
+
+```json
+{}
+```
+
+**Example response payload when a Payment Request is attached**
+
+```json
+{
+  "id": "207b5fb5-621e-4282-86c3-42ee47f87e74",
+  "patronCodeId": "V17FByEP9gm1shSG6a1Zzx",
+  "merchantId": "26d3Cp3rJmbMHnuNJmks2N",
+  "merchantName": "Centrapay Café",
+  "merchantConfigId": "5efbe2fb96c08357bb2b9242",
+  "value": { "currency": "NZD", "amount": "100" },
+  "paymentOptions": [
+    {
+      "amount": "100",
+      "assetType": "centrapay.nzd.test"
+    }
+  ],
+  "status": "new",
+  "createdAt": "2021-06-08T04:04:27.426Z",
+  "updatedAt": "2021-06-08T04:04:27.426Z",
+  "expiresAt": "2021-06-08T04:06:27.426Z",
+  "liveness": "test",
+  "expirySeconds": 120
+}
+```
+
+
+
+[Patron Code]: {% link api/patron-codes.md %}
+[Asset]: {% link api/assets/assets.md %}
+[PaymentOption]: #payment-option
+[LineItem]: #line-item
+[Payment Flows Guide]: {% link guides/payment-flows.md %}
+[Legacy Payment Requests]: {% link api/payment-requests/legacy-payment-requests.md %}

--- a/src/guides/payment-flows.md
+++ b/src/guides/payment-flows.md
@@ -58,9 +58,9 @@ be used.
 4. Merchant vending system optionally initiates refund via Centrapay API.
 
 
-[Payment Requests]: {% link api/transacting.md %}
-[Creates a Payment Request]: {% link api/transacting.md %}#requests-create
-[Payment Request Details]: {% link api/transacting.md %}#requests-info
-[Completes Payment]: {% link api/transacting.md %}#requests-pay
+[Payment Requests]: {% link api/payment-requests/payment-requests.md %}
+[Creates a Payment Request]: {% link api/payment-requests/legacy-payment-requests.md %}#requests-create
+[Payment Request Details]: {% link api/payment-requests/legacy-payment-requests.md %}#requests-info
+[Completes Payment]: {% link api/payment-requests/legacy-payment-requests.md %}#requests-pay
 [Patron Code]: {% link api/patron-codes.md %}
-[Fetch the Payment Request]: {% link api/transacting.md %}#patron-code
+[Fetch the Payment Request]: {% link api/payment-requests/legacy-payment-requests.md %}#patron-code


### PR DESCRIPTION
Multiple changes here relating to new payment request documentation:

* "transacting" is now "legacy payment requests"
* "get by patron code" is moved to new payment requests page
* initial payment request line items is modeled
* new "h4" tag for unanchored sub section headings
* new "monetary" data type