### PR TITLE
Rename "Guides Introduction" to "Guides" for SEO

### DIFF
--- a/src/guides/introduction.md
+++ b/src/guides/introduction.md
@@ -2,11 +2,11 @@
 layout: default
 nav_order: 1
 parent: Guides
-title: Guides Introduction
+title: Guides
 permalink: /guides/introduction
 ---
 
-# Guides Introduction
+# Guides
 
 Guides and examples of how to use Centrapay.
 


### PR DESCRIPTION
The "Guides Introduction" title looks weird on web search results.