### PR TITLE
add oauth link to example oidc consumer page

### DIFF
--- a/src/guides/example-oidc-consumer.md
+++ b/src/guides/example-oidc-consumer.md
@@ -11,6 +11,8 @@ This guide demonstrates how to integrate a browser based application with the
 Centrapay OAuth server using the [oidc-client-js][oidcjs]{:.external}
 JavaScript library.
 
+A good starting point for learning more about OIDC is Okta's [OAuth OIDC Illustrated Guide][okta-oidc]{:.external}.
+
 ## Contents
 {:.no_toc .text-delta}
 
@@ -140,3 +142,4 @@ async function handleLogoutOidcCallback() {
 
 
 [oidcjs]: https://github.com/IdentityModel/oidc-client-js
+[okta-oidc]: https://developer.okta.com/blog/2019/10/21/illustrated-guide-to-oauth-and-oidc


### PR DESCRIPTION
This link would be helpful on this page, as well as its existing place in the User Access Tokens section of the Auth guide. 